### PR TITLE
Default criteria's to stop fitting were added.

### DIFF
--- a/src/main/java/com/tornadoml/mnist/MNISTBase.java
+++ b/src/main/java/com/tornadoml/mnist/MNISTBase.java
@@ -6,7 +6,7 @@ import com.tornadoml.cpu.WeightsOptimizer.OptimizerType;
 
 public abstract class MNISTBase {
     @SuppressWarnings("SameParameterValue")
-    protected static void trainMnist(int maxEpochs, int... neuronsCount) throws Exception {
+    protected static void trainMnist( int... neuronsCount) throws Exception {
         var inputSize = 784;
         var outputSize = 10;
 
@@ -32,13 +32,12 @@ public abstract class MNISTBase {
             trainingLabelProbabilities[i][trainingLabels[i]] = 1.0f;
         }
 
-        network.train(trainingImages, trainingLabelProbabilities,
+        network.fit(trainingImages, trainingLabelProbabilities,
                 //frozen
                 inputSize, outputSize, trainingImages.length,
 
                 //variable
                 miniBatchSize,
-                maxEpochs,
                 learningRate, 20, true);
 
         var testImages = MNISTLoader.loadMNISTTestImages();

--- a/src/main/java/com/tornadoml/mnist/MNISTBench.java
+++ b/src/main/java/com/tornadoml/mnist/MNISTBench.java
@@ -4,7 +4,7 @@ package com.tornadoml.mnist;
 public class MNISTBench extends MNISTBase {
     public static void main(String[] args) throws Exception {
         try {
-            trainMnist(Integer.MAX_VALUE, 2500, 2000, 1500, 1000, 500);
+            trainMnist( 2500, 2000, 1500, 1000, 500);
         } catch (Exception e) {
             //noinspection CallToPrintStackTrace
             e.printStackTrace();

--- a/src/main/java/com/tornadoml/mnist/MNISTBenchLight.java
+++ b/src/main/java/com/tornadoml/mnist/MNISTBenchLight.java
@@ -5,7 +5,7 @@ package com.tornadoml.mnist;
 public class MNISTBenchLight extends MNISTBase {
     public static void main(String[] args) throws Exception {
         try {
-            trainMnist(500, 50, 40, 30, 20);
+            trainMnist(50, 40, 30, 20);
         } catch (Exception e) {
             //noinspection CallToPrintStackTrace
             e.printStackTrace();

--- a/src/test/kotlin/com/tornadoml/cpu/NeuralNetworkMSETests.kt
+++ b/src/test/kotlin/com/tornadoml/cpu/NeuralNetworkMSETests.kt
@@ -50,9 +50,9 @@ class NeuralNetworkMSETests {
         weights -= weightsDelta * alpha
         biases -= biasesDelta * alpha
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize, 1, 1,
-            1, alpha, -1, false
+            1, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(weights.toFlatArray(), layer.weights, 0.0001f)
@@ -133,7 +133,7 @@ class NeuralNetworkMSETests {
         weights -= weightsDelta * alpha / sampleSize
         biases -= biasesDelta.reduce() * alpha / sampleSize
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(),
             expected.transpose().toArray(),
             inputSize,
@@ -143,7 +143,7 @@ class NeuralNetworkMSETests {
             1,
             alpha,
             -1,
-            false
+            false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(weights.toFlatArray(), layer.weights, 0.0001f)
@@ -194,7 +194,7 @@ class NeuralNetworkMSETests {
             biases -= biasesDelta.reduce() / sampleSize * alpha
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(),
             expected.transpose().toArray(),
             inputSize,
@@ -204,7 +204,7 @@ class NeuralNetworkMSETests {
             epochs,
             alpha,
             -1,
-            false
+            false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(weights.toFlatArray(), layer.weights, 0.0001f)
@@ -262,7 +262,7 @@ class NeuralNetworkMSETests {
             }
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(),
             expected.transpose().toArray(),
             inputSize,
@@ -272,7 +272,7 @@ class NeuralNetworkMSETests {
             epochs,
             alpha,
             -1,
-            false
+            false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(weights.toFlatArray(), layer.weights, 0.0001f)
@@ -385,9 +385,9 @@ class NeuralNetworkMSETests {
         secondLayerBiases -= secondLayerBiasesDelta * alpha
 
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize, 1, 1,
-            1, alpha, -1, false
+            1, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -513,9 +513,9 @@ class NeuralNetworkMSETests {
         secondLayerBiases -= secondLayerBiasesDelta.reduce() * alpha / samplesCount
 
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize, samplesCount,
-            samplesCount, 1, alpha, -1, false
+            samplesCount, 1, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -595,9 +595,9 @@ class NeuralNetworkMSETests {
             secondLayerBiases -= secondLayerBiasesDelta.reduce() * alpha / samplesCount
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize, samplesCount,
-            samplesCount, epochs, alpha, -1, false
+            samplesCount, epochs, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -686,9 +686,9 @@ class NeuralNetworkMSETests {
             }
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize, samplesCount,
-            miniBatchSize, epochs, alpha, -1, false
+            miniBatchSize, epochs, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -853,10 +853,10 @@ class NeuralNetworkMSETests {
         thirdLayerWeights -= thirdLayerWeightsDelta * alpha
         thirdLayerBiases -= thirdLayerBiasesDelta * alpha
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize,
             1, 1,
-            1, alpha, -1, false
+            1, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -1038,10 +1038,10 @@ class NeuralNetworkMSETests {
         thirdLayerWeights -= thirdLayerWeightsDelta * alpha / sampleCount
         thirdLayerBiases -= thirdLayerBiasesDelta.reduce() * alpha / sampleCount
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize,
             sampleCount, sampleCount,
-            1, alpha, -1, false
+            1, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -1161,10 +1161,10 @@ class NeuralNetworkMSETests {
             thirdLayerBiases -= thirdLayerBiasesDelta.reduce() * alpha / sampleCount
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize,
             sampleCount, sampleCount,
-            epochsCount, alpha, -1, false
+            epochsCount, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)
@@ -1290,10 +1290,10 @@ class NeuralNetworkMSETests {
             }
         }
 
-        neuralNetwork.train(
+        neuralNetwork.fit(
             input.transpose().toArray(), expected.transpose().toArray(), inputSize, outputSize,
             samplesCount, miniBatchSize,
-            epochsCount, alpha, -1, false
+            epochsCount, alpha, -1, false, Float.MIN_VALUE
         )
 
         Assertions.assertArrayEquals(firstLayerWeights.toFlatArray(), firstLayer.weights, 0.0001f)


### PR DESCRIPTION
Fitting is stopped if the percent of change of cost function during fitting reaches the threshold limit or cost function overflows. The default amount of epochs is set to 100, and the default threshold limit is set to 0.001.